### PR TITLE
Feature, option to disable the subscribe button

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ After installation, you can run `jekyll serve` to check out your site, but befor
 | `lang`     | string | The language of the site; The default value is `en`. |
 | `paginate` | int    | The number of posts on each page. |
 | `date_format` | string | The date format; The default value is `%b %-d, %Y`. |
-| `subscribe` | boolean | If the subscribe button should be shown |
+| `subscribe` | boolean | Show the subsribe feed button. |
 
 ## Archive Pages
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ After installation, you can run `jekyll serve` to check out your site, but befor
 | `lang`     | string | The language of the site; The default value is `en`. |
 | `paginate` | int    | The number of posts on each page. |
 | `date_format` | string | The date format; The default value is `%b %-d, %Y`. |
+| `subscribe` | boolean | If the subscribe button should be shown |
 
 ## Archive Pages
 

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -32,7 +32,7 @@
   </ul>
 </div>
 
-{% if site.subscribe == true -%}
+{% if site.subscribe != false -%}
 <div class="sidebar-section feed-subscribe">
   <a href="{{ 'feed.xml' | relative_url }}">
     <i class="sidebar-icon fas fa-rss"></i><span>Subscribe</span>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -32,11 +32,13 @@
   </ul>
 </div>
 
+{% if site.subscribe == true -%}
 <div class="sidebar-section feed-subscribe">
   <a href="{{ 'feed.xml' | relative_url }}">
     <i class="sidebar-icon fas fa-rss"></i><span>Subscribe</span>
   </a>
 </div>
+{%- endif %}
 
 {% if site.data.social -%}
   <div class="sidebar-section">


### PR DESCRIPTION
# What have I done?
I added a config variable for disabling the subscribe button under the avatar.

# How have I done that?
I added a If statement that looks for false to disable it.

# Considerations
- Make the sane default show or not show
  - Made it show because of compatibility with current websites

# Testing
- [x] Use the theme with no `subscribe` in the config -> subscribe button is shown
- [x] Use the theme with `subscribe` set to `true` in config -> subscribe button is shown
- [x] Use the theme with `subscribe` set to `false` in config -> subscribe button is not shown